### PR TITLE
Set the websockets loop to continue on connection closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /dataSources.local.xml
 .idea
 .envrc
+.direnv/


### PR DESCRIPTION
This sets our websockets to continue and reconnect instead of failing
out when the connection is closed. Tested locally.

resolves jc-cb/prime-workshop-scripts#8